### PR TITLE
[FIXED] TypeError: Can't instantiate abstract class SliceSampler with abstract methods load_state_dict, state_dict

### DIFF
--- a/tdmpc2/common/samplers.py
+++ b/tdmpc2/common/samplers.py
@@ -345,6 +345,12 @@ class SliceSampler(Sampler):
         # no op
         ...
 
+    def state_dict(self):
+        ...
+
+    def load_state_dict(self, state_dict):
+        ...
+
     def __getstate__(self):
         state = copy(self.__dict__)
         state["_cache"] = {}


### PR DESCRIPTION
Error: The error was caused by torch-rl introducing new abstract methods in Sample class: load_state_dict, state_dict

Fix: Overloading both methods in SliceSampler in [common/sample.py](https://github.com/nicklashansen/tdmpc2/blob/episodic-rl/tdmpc2/common/samplers.py)

Branch: episodic-rl

Related Issues: [Mentioned here](https://github.com/nicklashansen/tdmpc2/issues/17#issuecomment-1932670729)
